### PR TITLE
Exclude learners that completed the course from participants

### DIFF
--- a/includes/class-sensei-course-participants-widget.php
+++ b/includes/class-sensei-course-participants-widget.php
@@ -85,17 +85,16 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 	 * @return void
 	 */
 	public function widget( $args, $instance ) {
-		$before_widget     = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
-		$after_widget      = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
-		$before_title      = isset( $args['before_title'] ) ? $args['before_title'] : '';
-		$after_title       = isset( $args['after_title'] ) ? $args['after_title'] : '';
-		$title             = isset( $instance['title'] ) ? $instance['title'] : '';
-		$exclude_completed = isset( $instance['exclude_completed'] ) ? (bool) $instance['exclude_completed'] : false;
-		$display           = 'list';
-		$limit             = 5;
-		$size              = 50;
-		$order             = 'ASC';
-		$orderby           = 'name';
+		$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+		$after_widget  = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+		$before_title  = isset( $args['before_title'] ) ? $args['before_title'] : '';
+		$after_title   = isset( $args['after_title'] ) ? $args['after_title'] : '';
+		$title         = isset( $instance['title'] ) ? $instance['title'] : '';
+		$display       = 'list';
+		$limit         = 5;
+		$size          = 50;
+		$order         = 'ASC';
+		$orderby       = 'name';
 
 		if ( ! ( is_singular( 'course' ) || is_singular( 'lesson' ) ||
 			 is_singular( 'quiz' ) || is_tax( 'module' ) ) ) {
@@ -127,14 +126,10 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 			$order = $instance['order'];
 		}
 
-		$course_id = Sensei_Course_Participants()->get_course_id();
-
-		Sensei_Course_Participants()->get_course_participant_count( $course_id, $exclude_completed );
-
 		/**
 		 * @var WP_User[] $learners
 		 */
-		$learners = Sensei_Course_Participants()->get_course_learners( $order, $orderby, $exclude_completed );
+		$learners        = Sensei_Course_Participants()->get_course_learners( $order, $orderby );
 		$public_profiles = false;
 
 		if ( isset( Sensei()->settings->settings[ 'learner_profile_enable' ] ) && Sensei()->settings->settings[ 'learner_profile_enable' ] ) {
@@ -226,7 +221,7 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 	 * @param  array $old_instance Previous settings.
 	 * @return array               Updated settings.
 	 */
-	public function update( $new_instance, $old_instance ) {
+	public function update ( $new_instance, $old_instance ) {
 		$instance = $old_instance;
 
 		// Strip tags for title and limit to remove HTML (important for text inputs)
@@ -238,8 +233,6 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 		$instance['orderby'] = esc_attr( $new_instance['orderby'] );
 		$instance['order']   = esc_attr( $new_instance['order'] );
 		$instance['display'] = esc_attr( $new_instance['display'] );
-
-		$instance['exclude_completed'] = (bool)$new_instance['exclude_completed'];
 
 		return $instance;
 	}
@@ -256,13 +249,12 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 		// Set up some default widget settings.
 		// Make sure all keys are added here, even with empty string values.
 		$defaults = array(
-			'title'             => '',
-			'limit'             => 5,
-			'size'              => 50,
-			'orderby'           => 'user_registered',
-			'order'             => 'ASC',
-			'display'           => 'list',
-			'exclude_completed' => 0,
+			'title'   => '',
+			'limit'   => 5,
+			'size'    => 50,
+			'orderby' => 'user_registered',
+			'order'   => 'ASC',
+			'display' => 'list',
 		);
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
@@ -308,11 +300,6 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 				<option value="<?php echo esc_attr( $k ); ?>"<?php selected( $instance['display'], $k ); ?>><?php echo esc_html( $v ); ?></option>
 			<?php } ?>
 			</select>
-		</p>
-		<!-- Widget Exclude Completed: Checkbox -->
-		<p>
-			<label for="<?php echo esc_attr( $this->get_field_id( 'exclude_completed' ) ); ?>"><?php esc_html_e( 'Exclude Completed:', 'sensei-course-participants' ); ?></label>
-			<input type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'exclude_completed' ) ); ?>" <?php checked( $instance['exclude_completed'] ); ?> id="<?php echo esc_attr( $this->get_field_id( 'exclude_completed' ) ); ?>">
 		</p>
 
 		<?php

--- a/includes/class-sensei-course-participants-widget.php
+++ b/includes/class-sensei-course-participants-widget.php
@@ -85,16 +85,17 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 	 * @return void
 	 */
 	public function widget( $args, $instance ) {
-		$before_widget = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
-		$after_widget  = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
-		$before_title  = isset( $args['before_title'] ) ? $args['before_title'] : '';
-		$after_title   = isset( $args['after_title'] ) ? $args['after_title'] : '';
-		$title         = isset( $instance['title'] ) ? $instance['title'] : '';
-		$display       = 'list';
-		$limit         = 5;
-		$size          = 50;
-		$order         = 'ASC';
-		$orderby       = 'name';
+		$before_widget     = isset( $args['before_widget'] ) ? $args['before_widget'] : '';
+		$after_widget      = isset( $args['after_widget'] ) ? $args['after_widget'] : '';
+		$before_title      = isset( $args['before_title'] ) ? $args['before_title'] : '';
+		$after_title       = isset( $args['after_title'] ) ? $args['after_title'] : '';
+		$title             = isset( $instance['title'] ) ? $instance['title'] : '';
+		$exclude_completed = isset( $instance['exclude_completed'] ) ? (bool) $instance['exclude_completed'] : false;
+		$display           = 'list';
+		$limit             = 5;
+		$size              = 50;
+		$order             = 'ASC';
+		$orderby           = 'name';
 
 		if ( ! ( is_singular( 'course' ) || is_singular( 'lesson' ) ||
 			 is_singular( 'quiz' ) || is_tax( 'module' ) ) ) {
@@ -126,10 +127,14 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 			$order = $instance['order'];
 		}
 
+		$course_id = Sensei_Course_Participants()->get_course_id();
+
+		Sensei_Course_Participants()->get_course_participant_count( $course_id, $exclude_completed );
+
 		/**
 		 * @var WP_User[] $learners
 		 */
-		$learners        = Sensei_Course_Participants()->get_course_learners( $order, $orderby );
+		$learners = Sensei_Course_Participants()->get_course_learners( $order, $orderby, $exclude_completed );
 		$public_profiles = false;
 
 		if ( isset( Sensei()->settings->settings[ 'learner_profile_enable' ] ) && Sensei()->settings->settings[ 'learner_profile_enable' ] ) {
@@ -221,7 +226,7 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 	 * @param  array $old_instance Previous settings.
 	 * @return array               Updated settings.
 	 */
-	public function update ( $new_instance, $old_instance ) {
+	public function update( $new_instance, $old_instance ) {
 		$instance = $old_instance;
 
 		// Strip tags for title and limit to remove HTML (important for text inputs)
@@ -233,6 +238,8 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 		$instance['orderby'] = esc_attr( $new_instance['orderby'] );
 		$instance['order']   = esc_attr( $new_instance['order'] );
 		$instance['display'] = esc_attr( $new_instance['display'] );
+
+		$instance['exclude_completed'] = (bool)$new_instance['exclude_completed'];
 
 		return $instance;
 	}
@@ -249,12 +256,13 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 		// Set up some default widget settings.
 		// Make sure all keys are added here, even with empty string values.
 		$defaults = array(
-			'title'   => '',
-			'limit'   => 5,
-			'size'    => 50,
-			'orderby' => 'user_registered',
-			'order'   => 'ASC',
-			'display' => 'list',
+			'title'             => '',
+			'limit'             => 5,
+			'size'              => 50,
+			'orderby'           => 'user_registered',
+			'order'             => 'ASC',
+			'display'           => 'list',
+			'exclude_completed' => 0,
 		);
 
 		$instance = wp_parse_args( (array) $instance, $defaults );
@@ -300,6 +308,11 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 				<option value="<?php echo esc_attr( $k ); ?>"<?php selected( $instance['display'], $k ); ?>><?php echo esc_html( $v ); ?></option>
 			<?php } ?>
 			</select>
+		</p>
+		<!-- Widget Exclude Completed: Checkbox -->
+		<p>
+			<label for="<?php echo esc_attr( $this->get_field_id( 'exclude_completed' ) ); ?>"><?php esc_html_e( 'Exclude Completed:', 'sensei-course-participants' ); ?></label>
+			<input type="checkbox" name="<?php echo esc_attr( $this->get_field_name( 'exclude_completed' ) ); ?>" <?php checked( $instance['exclude_completed'] ); ?> id="<?php echo esc_attr( $this->get_field_id( 'exclude_completed' ) ); ?>">
 		</p>
 
 		<?php

--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -58,6 +58,7 @@ class Sensei_Course_Participants {
 	 * @since  1.0.0
 	 */
 	private $script_suffix;
+	private $course_learner_count = null;
 
 	/**
 	 * Set the default properties and hooks methods.
@@ -155,10 +156,13 @@ class Sensei_Course_Participants {
 	 * Get the number of learners taking the current course
 	 *
 	 * @since  1.0.0
+	 *
+	 * @param int  $post_id           Post ID.
+	 * @param bool $exclude_completed True if we should exclude completed learners from the participant count.
 	 * @return integer
 	 */
-	public function get_course_participant_count( $post_id = 0 ) {
-		if ( empty( $post_id ) ) {
+	public function get_course_participant_count( $post_id = 0, $exclude_completed = false ) {
+		if( ! $post_id ) {
 			return 0;
 		}
 
@@ -168,7 +172,7 @@ class Sensei_Course_Participants {
 			'count'   => true,
 			'number'  => 0,
 			'offset'  => 0,
-			'status'  => 'any',
+			'status'  => $exclude_completed ? 'in-progress' : 'any',
 		);
 
 		$course_learners = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, false );
@@ -184,13 +188,14 @@ class Sensei_Course_Participants {
 	 * @param  string $orderby  How to determine the order of learners
 	 * @return array  $learners The array of learners
 	 */
-	public function get_course_learners( $order, $orderby ) {
+	public function get_course_learners( $order, $orderby, $exclude_completed = false ) {
+
 		$activity_args = array(
 			'post_id' => absint( $this->get_course_id() ),
 			'type'    => 'sensei_course_status',
 			'number'  => 0,
 			'offset'  => 0,
-			'status'  => 'any',
+			'status'  => $exclude_completed ? 'in-progress' : 'any',
 		);
 
 		$users = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, true );

--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -116,7 +116,7 @@ class Sensei_Course_Participants {
 	 * Display course participants on course loop and single course
 	 *
 	 * @since  1.0.0
-	 * @param  WP_Post|integer $post_item         Post object or ID.
+	 * @param  WP_Post|int $post_item Post object or ID.
 	 * @return void
 	 */
 	public function display_course_participant_count( $post_item = 0 ) {


### PR DESCRIPTION
One caveat is that the count of learners will always show `any` learner status, because it is not part of the widget per se. Will look into fixing this as I go along.

 closes #4