### PR TITLE
Load most of plugin and check dependencies after other plugins have loaded

### DIFF
--- a/includes/class-sensei-course-participants-dependency-checker.php
+++ b/includes/class-sensei-course-participants-dependency-checker.php
@@ -88,7 +88,7 @@ class Sensei_Course_Participants_Dependency_Checker {
 		}
 
 		// translators: %1$s is version of PHP that this plugin requires; %2$s is the version of PHP WordPress is running on.
-		$message = sprintf( __( '<strong>Sensei Course Participants</strong> requires PHP version %1$s but you are running %2$s.', 'sensei-course-participants' ), self::MINIMUM_PHP_VERSION, phpversion() );
+		$message = sprintf( __( '<strong>Sensei Course Participants</strong> requires a minimum PHP version of %1$s, but you are running %2$s.', 'sensei-course-participants' ), self::MINIMUM_PHP_VERSION, phpversion() );
 		echo '<div class="error"><p>';
 		echo wp_kses( $message, array( 'strong' => array() ) );
 		$php_update_url = 'https://wordpress.org/support/update-php/';

--- a/includes/class-sensei-course-participants-dependency-checker.php
+++ b/includes/class-sensei-course-participants-dependency-checker.php
@@ -13,39 +13,29 @@ class Sensei_Course_Participants_Dependency_Checker {
 	const MINIMUM_SENSEI_VERSION = '1.11.0';
 
 	/**
-	 * The list of active plugins.
-	 *
-	 * @var array
-	 */
-	private static $active_plugins;
-
-	/**
-	 * Get active plugins.
-	 *
-	 * @return string[]
-	 */
-	private static function get_active_plugins() {
-		if ( ! isset( self::$active_plugins ) ) {
-			self::$active_plugins = (array) get_option( 'active_plugins', array() );
-
-			if ( is_multisite() ) {
-				self::$active_plugins = array_merge( self::$active_plugins, get_site_option( 'active_sitewide_plugins', array() ) );
-			}
-		}
-		return self::$active_plugins;
-	}
-
-	/**
 	 * Checks if all dependencies are met.
 	 *
 	 * @return bool
 	 */
-	public static function are_dependencies_met() {
+	public static function are_system_dependencies_met() {
 		$are_met = true;
 		if ( ! self::check_php() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_php_notice' ) );
 			$are_met = false;
 		}
+		if ( ! $are_met ) {
+			add_action( 'admin_init', array( __CLASS__, 'deactivate_self' ) );
+		}
+		return $are_met;
+	}
+
+	/**
+	 * Checks if all plugin dependencies are met.
+	 *
+	 * @return bool
+	 */
+	public static function are_plugin_dependencies_met() {
+		$are_met = true;
 		if ( ! self::check_sensei() ) {
 			add_action( 'admin_notices', array( __CLASS__, 'add_sensei_notice' ) );
 			$are_met = false;
@@ -63,28 +53,19 @@ class Sensei_Course_Participants_Dependency_Checker {
 	}
 
 	/**
+	 * Deactivate self.
+	 */
+	public static function deactivate_self() {
+		deactivate_plugins( SENSEI_COURSE_PARTICIPANTS_PLUGIN_BASENAME );
+	}
+
+	/**
 	 * Checks for our Sensei dependency.
 	 *
 	 * @return bool
 	 */
 	private static function check_sensei() {
-		$active_plugins = self::get_active_plugins();
-
-		$search_sensei = array(
-			'sensei/sensei.php',                     // Sensei 2.x from WordPress.org.
-			'sensei/woothemes-sensei.php',           // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-			'woothemes-sensei/woothemes-sensei.php', // Sensei 1.x or Sensei 2.x Compatibility Plugin.
-		);
-
-		$found_sensei = false;
-		foreach ( $search_sensei as $basename ) {
-			if ( in_array( $basename, $active_plugins, true ) || array_key_exists( $basename, $active_plugins ) ) {
-				$found_sensei = true;
-				break;
-			}
-		}
-
-		if ( ! $found_sensei && ! class_exists( 'Sensei_Main' ) ) {
+		if ( ! class_exists( 'Sensei_Main' ) ) {
 			return false;
 		}
 

--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -72,16 +72,19 @@ class Sensei_Course_Participants {
 		$this->assets_url    = esc_url( trailingslashit( plugins_url( '/assets/', SENSEI_COURSE_PARTICIPANTS_PLUGIN_FILE ) ) );
 		$this->script_suffix = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG ? '' : '.min';
 
+		$this->load_plugin_textdomain();
+
 		register_activation_hook( SENSEI_COURSE_PARTICIPANTS_PLUGIN_FILE, array( $this, 'install' ) );
 
-		// Handle localisation
-		add_action( 'init', array( $this, 'load_plugin_textdomain' ), 0 );
 	}
 
 	/**
 	 * Set up all actions and filters.
 	 */
 	public static function init() {
+		$instance = self::instance();
+		add_action( 'init', array( $instance, 'load_localisation' ), 0 );
+
 		if ( ! Sensei_Course_Participants_Dependency_Checker::are_plugin_dependencies_met() ) {
 			return;
 		}
@@ -95,8 +98,6 @@ class Sensei_Course_Participants {
 		function Sensei_Course_Participants() {
 			return Sensei_Course_Participants::instance();
 		}
-
-		$instance = self::instance();
 
 		// Load frontend JS & CSS
 		add_action( 'wp_enqueue_scripts', array( $instance, 'enqueue_styles' ), 10 );
@@ -313,7 +314,15 @@ class Sensei_Course_Participants {
 		$locale = apply_filters( 'plugin_locale' , get_locale() , $domain );
 
 		load_textdomain( $domain , WP_LANG_DIR . '/' . $domain . '/' . $domain . '-' . $locale . '.mo' );
-		load_plugin_textdomain( $domain , FALSE , dirname( SENSEI_COURSE_PARTICIPANTS_PLUGIN_BASENAME ) . '/languages/' );
+	}
+
+	/**
+	 * Load plugin localisation.
+	 *
+	 * @since   2.0.0
+	 */
+	public function load_localisation () {
+		load_plugin_textdomain( 'sensei-course-participants', false , dirname( SENSEI_COURSE_PARTICIPANTS_PLUGIN_BASENAME ) . '/languages/' );
 	}
 
 	/**

--- a/sensei-course-participants.php
+++ b/sensei-course-participants.php
@@ -8,6 +8,7 @@
  * Author URI: https://automattic.com/
  * Requires at least: 3.8
  * Tested up to: 4.1
+ * Requires PHP: 5.6
  * Text Domain: sensei-course-participants
  * Domain Path: /languages/
  * Woo: 435834:f6479a8a3a01ac11794f32be22b0682f
@@ -21,22 +22,19 @@ if ( ! defined( 'ABSPATH' ) ) {
 	exit;
 }
 
+define( 'SENSEI_COURSE_PARTICIPANTS_VERSION', '1.1.3' );
+define( 'SENSEI_COURSE_PARTICIPANTS_PLUGIN_FILE', __FILE__ );
+define( 'SENSEI_COURSE_PARTICIPANTS_PLUGIN_BASENAME', plugin_basename( __FILE__ ) );
+
 require_once dirname( __FILE__ ) . '/includes/class-sensei-course-participants-dependency-checker.php';
 
-if ( ! Sensei_Course_Participants_Dependency_Checker::are_dependencies_met() ) {
+if ( ! Sensei_Course_Participants_Dependency_Checker::are_system_dependencies_met() ) {
 	return;
 }
 
-require_once( dirname( __FILE__ ) . '/includes/class-sensei-course-participants.php' );
+require_once dirname( __FILE__ ) . '/includes/class-sensei-course-participants.php';
 
-/**
- * Returns the main instance of Sensei_Course_Participants to prevent the need to use globals.
- *
- * @since  1.0.0
- * @return object Sensei_Course_Participants
- */
-function Sensei_Course_Participants() {
-	return Sensei_Course_Participants::instance( __FILE__, '1.1.3' );
-}
+// Load the plugin after all the other plugins have loaded.
+add_action( 'plugins_loaded', array( 'Sensei_Course_Participants', 'init' ), 5 ) ;
 
-Sensei_Course_Participants();
+Sensei_Course_Participants::instance();


### PR DESCRIPTION
This brings over the work to check dependencies and load plugin after the other plugins have loaded. This simplifies our Sensei check and makes it work for non-standard install locations.

### Testing Instructions
- If activated, deactivate all versions of Sensei. 
- Remove `sensei-version` and `woothemes-sensei-version` options.
- If not active, activate this plugin on built version of this branch. Verify the Sensei dependency message shows on Plugins page and Dashboard page.
- Activate Sensei 1.12.x. Verify message disappears.
- Deactivate Sensei 1.12.x. Activate Sensei 2.x. Verify message is still gone.
- Deactivate Sensei 2.x and activate Sensei with WooCommerce Paid Courses. Verify message is still gone.

Test PHP version:
- Activate Sensei and version of this branch on PHP 5.2-5.5. Verify PHP version notice appears.

In addition:
- Make sure version is logged in options (`sensei_course_participants_version`) on activation even when Sensei isn't first activated.