### PR TITLE
Add filter for participant profile URL

### DIFF
--- a/includes/class-sensei-course-participants-widget.php
+++ b/includes/class-sensei-course-participants-widget.php
@@ -191,7 +191,7 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 				 * @since 2.0.0
 				 *
 				 * @param string|bool $profile_url The learner's public profile URL if public profiles are enabled. Otherwise, this will be false.
-				 * @param WP_Post     $learner     The learner being displayed.
+				 * @param WP_User     $learner     The learner being displayed.
 				 *
 				 * @return string|bool The profile URL to be used, or false.
 				 */

--- a/includes/class-sensei-course-participants-widget.php
+++ b/includes/class-sensei-course-participants-widget.php
@@ -180,8 +180,24 @@ class Sensei_Course_Participants_Widget extends WP_Widget {
 					$learner_name = '<h3 itemprop="name" class="learner-name">' . esc_html( $display_name ) . '</h3>' . "\n";
 				}
 
+				$profile_url = false;
 				if ( true === $public_profiles ) {
 					$profile_url  = Sensei()->learner_profiles->get_permalink( $learner->ID );
+				}
+
+				/**
+				 * Filter the learner profile URL for course participants.
+				 *
+				 * @since 2.0.0
+				 *
+				 * @param string|bool $profile_url The learner's public profile URL if public profiles are enabled. Otherwise, this will be false.
+				 * @param WP_Post     $learner     The learner being displayed.
+				 *
+				 * @return string|bool The profile URL to be used, or false.
+				 */
+				$profile_url = apply_filters( 'sensei_course_participants_profile_url', $profile_url, $learner );
+
+				if ( $profile_url ) {
 					$link         = '<a href="' . esc_url( $profile_url ) . '" title="' . esc_attr__( 'View public learner profile', 'sensei-course-participants' ) . '">';
 					$image        = $link . $image . '</a>';
 					$learner_name = $link . $learner_name . '</a>';


### PR DESCRIPTION
Fixes https://github.com/woocommerce/sensei-course-participants/issues/20

## Testing Instructions

- Add the Course Participants widget to the sidebar.
- Enable public learner profiles. Ensure that the widget links to the profiles.
- Add the following code snippet, and ensure the widget links instead to `http://example.com/learner/<learner-id>`:

```php
add_filter( 'sensei_course_participants_profile_url', function( $profile_url, $learner ) {
	return 'http://example.com/learner/' . $learner->ID;
}, 10, 2 );
```
- Change the code snippet to the following, and ensure that the widget no longer links anywhere:
```php
add_filter( 'sensei_course_participants_profile_url', function( $profile_url, $learner ) {
	return false;
}, 10, 2 );
```