### PR TITLE
Change to get enrolled participants instead of in progress

### DIFF
--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -103,21 +103,6 @@ class Sensei_Course_Participants {
 	}
 
 	/**
-	 * If the new enrolment provider method is not available, return true.
-	 * 
-	 * @since 2.0.1
-	 *
-	 * @return bool
-	 */
-	public static function use_legacy_enrolment_method() {
-		if ( ! interface_exists( '\Sensei_Course_Enrolment_Provider_Interface' ) ) {
-			return true;
-		}
-
-		return false;
-	}
-
-	/**
 	 * Display course participants on course loop and single course
 	 *
 	 * @since  1.0.0
@@ -173,6 +158,21 @@ class Sensei_Course_Participants {
 	}
 
 	/**
+	 * If the new enrolment provider method is not available, return true.
+	 *
+	 * @since 2.0.1
+	 *
+	 * @return bool
+	 */
+	private function use_legacy_enrolment_method() {
+		if ( ! interface_exists( '\Sensei_Course_Enrolment_Provider_Interface' ) ) {
+			return true;
+		}
+
+		return false;
+	}
+
+	/**
 	 * Get the number of learners taking the current course.
 	 *
 	 * @since 1.0.0
@@ -189,7 +189,7 @@ class Sensei_Course_Participants {
 
 		$exclude_completed = $this->exclude_completed_participants( $post_id );
 
-		if ( ! self::use_legacy_enrolment_method() ) {
+		if ( ! $this->use_legacy_enrolment_method() ) {
 			return count( $this->get_enrolled_participants_ids( $post_id, $exclude_completed ) );
 		}
 
@@ -223,7 +223,7 @@ class Sensei_Course_Participants {
 		$post_id           = $this->get_course_id();
 		$exclude_completed = $this->exclude_completed_participants( $post_id );
 
-		if ( ! self::use_legacy_enrolment_method() ) {
+		if ( ! $this->use_legacy_enrolment_method() ) {
 			$user_ids = $this->get_enrolled_participants_ids( $post_id, $exclude_completed );
 		} else {
 			$activity_args     = array(

--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -317,9 +317,12 @@ class Sensei_Course_Participants {
 		$user_ids = Sensei_Course_Enrolment::get_course_instance( $course_id )->get_enrolled_user_ids();
 
 		if ( $exclude_completed ) {
-			$user_ids = array_filter( $user_ids, function( $user_id ) use ($course_id) {
-				return ! WooThemes_Sensei_Utils::user_completed_course( $course_id, $user_id );
-			} );
+			$user_ids = array_filter(
+				$user_ids,
+				function( $user_id ) use ($course_id) {
+					return ! WooThemes_Sensei_Utils::user_completed_course( $course_id, $user_id );
+				}
+			);
 		}
 
 		return $user_ids;

--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -311,7 +311,7 @@ class Sensei_Course_Participants {
 	 * @param int  $course_id         Course ID.
 	 * @param bool $exclude_completed Flag if should exclude the completed participants.
 	 * 
-	 * @return void
+	 * @return int[]
 	 */
 	private function get_enrolled_participants_ids( $course_id, $exclude_completed ) {
 		$user_ids = Sensei_Course_Enrolment::get_course_instance( $course_id )->get_enrolled_user_ids();

--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -202,7 +202,7 @@ class Sensei_Course_Participants {
 			'status'  => $exclude_completed ? 'in-progress' : 'any',
 		);
 
-		$course_learners = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, false );
+		$course_learners = Sensei_Utils::sensei_check_for_activity( $activity_args, false );
 
 		return $course_learners;
 	}
@@ -234,7 +234,7 @@ class Sensei_Course_Participants {
 				'status'  => $exclude_completed ? 'in-progress' : 'any',
 			);
 
-			$users = WooThemes_Sensei_Utils::sensei_check_for_activity( $activity_args, true );
+			$users = Sensei_Utils::sensei_check_for_activity( $activity_args, true );
 
 			if ( ! is_array( $users ) ) {
 				$users = array( $users );
@@ -320,7 +320,7 @@ class Sensei_Course_Participants {
 			$user_ids = array_filter(
 				$user_ids,
 				function( $user_id ) use ($course_id) {
-					return ! WooThemes_Sensei_Utils::user_completed_course( $course_id, $user_id );
+					return ! Sensei_Utils::user_completed_course( $course_id, $user_id );
 				}
 			);
 		}


### PR DESCRIPTION
#### Changes proposed in this Pull Request:

* [Course participants](https://woocommerce.com/products/sensei-course-participants/) should count/show the enrolled users instead of the "in progress" users when enrollments are available.
  * The counter was updated to count the enrolled users.
  * The widget was updated to show the enrolled users.

I think we can keep the same texts, right? If someone has a different opinion, please let me know:
- `6 learners taking this course`
- `There are no other learners currently taking this course. Be the first!`

#### Testing instructions:

* Activate the `Sensei Course Participants` plugin.
* Create a course.
* Create multiple users.
* Enroll the users to the course.
* Add the `Sensei - Course Participants` widget to the sidebar.
* Open the course page and check the counter and the users listed in the widget.
* Unenroll a user with progress.
* The user should not appear more on the list and should not be counted.
* You can also complete the course with some users and test adding this snippet to test if the filter continues working properly (should include completed participants):
  ```
  add_filter( 'sensei_course_participants_exclude_completed_participants', __return_false() );
  ```
* You can also checkout the sensei in the `version/2.4.0` to make sure it continues working (getting the users in progress).