### PR TITLE
Fix error when using old version of Sensei

### DIFF
--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -203,7 +203,12 @@ class Sensei_Course_Participants {
 	private function should_prepend_to_the_content() {
 		global $post;
 
-		$should_prepend_to_the_content = is_singular( 'course' ) && ! Sensei()->course->is_legacy_course( $post );
+		$is_legacy_course = true;
+		if ( method_exists( Sensei()->course, 'is_legacy_course' ) ) {
+			$is_legacy_course = Sensei()->course->is_legacy_course( $post );
+		}
+
+		$should_prepend_to_the_content = is_singular( 'course' ) && ! $is_legacy_course;
 
 		/**
 		 * Change whether the course participant count HTML should be prepended


### PR DESCRIPTION
Regression from https://github.com/woocommerce/sensei-course-participants/pull/69

### Changes proposed in this Pull Request

* Add a check for the `Sensei()->course->is_legacy_course()` method before calling it. If it does not exist, consider the course to be a legacy course.

### Testing instructions

* Open a course in the frontend on an old version of Sensei (version 3.5.3 is fine).
* You should see the Course Participants count, and you should not see a PHP fatal.

Previously, this error was being thrown:

<img width="719" alt="Screen Shot 2020-11-13 at 16 31 52" src="https://user-images.githubusercontent.com/842193/99118344-45006f80-25ef-11eb-916b-c98899dabe26.png">