### PR TITLE
Rename filter

### DIFF
--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -214,7 +214,7 @@ class Sensei_Course_Participants {
 		 * @param bool    $should_prepend_to_the_content Whether we should prepend the HTML to `the_content`.
 		 * @param WP_Post $post                          The current post.
 		 */
-		return apply_filters( 'sensei_course_participants_should_prepend_to_the_content', $should_prepend_to_the_content, $post );
+		return apply_filters( 'sensei_course_participants_prepend_to_the_content', $should_prepend_to_the_content, $post );
 	}
 
 	/**


### PR DESCRIPTION
Change the filter name from `sensei_course_participants_should_prepend_to_the_content` to `sensei_course_participants_prepend_to_the_content`.

See https://github.com/woocommerce/sensei-media-attachments/pull/97#issuecomment-727989573

### Filter
`sensei_course_participants_prepend_to_the_content` - Change whether the course participant count HTML should be prepended to `the_content` rather than using Sensei's custom hooks.