### PR TITLE
Add readme.txt

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -1,0 +1,22 @@
+=== Sensei Course Participants ===
+Contributors: automattic, alexsanford1, donnapep, jakeom, gikaragia, renathoc, yscik
+Tags: course, participants, members, course participants, sensei lms, sensei
+Requires at least: 5.3
+Tested up to: 5.5
+Requires PHP: 7.0
+Stable tag: 2.0.2
+License: GPLv2+
+License URI: http://www.gnu.org/licenses/gpl-2.0.html
+
+Sensei Course Participants shows your site visitors how many people are currently taking each course.
+
+== Description ==
+
+People are more likely to sign up for a course if they can see that it’s already popular, right?
+
+Sensei Course Participants shows your site visitors how many people are currently taking each course.
+
+There’s also an optional widget, which you can add to your sidebar, to display a list of all the learners taking the course. If you have public profiles enabled it will also link to each learner’s profile.
+
+== Changelog ==
+[See changelog for all versions](https://raw.githubusercontent.com/woocommerce/sensei-course-participants/master/changelog.txt).


### PR DESCRIPTION
### Changes proposed in this Pull Request

* Add `readme.txt` to the repo. The purpose of this change now is to start using the Woorelease. When we migrate it to wordpress.org probably we'll want to add the screenshots too.

I got the text from: https://woocommerce.com/pt-br/products/sensei-course-participants/

### Testing instructions

* Run `php woorelease.phar simulate https://github.com/woocommerce/sensei-course-participants/tree/add/readme-txt`