### PR TITLE
Change priority of action that participant count hooks into

### DIFF
--- a/includes/class-sensei-course-participants.php
+++ b/includes/class-sensei-course-participants.php
@@ -96,7 +96,7 @@ class Sensei_Course_Participants {
 
 		// Display course participants on course loop and single course
 		add_filter( 'the_content', array( $instance, 'single_course_prepend_course_participant_count' ), 15 );
-		add_action( 'sensei_single_course_content_inside_before', array( $instance, 'display_course_participant_count' ), 15 );
+		add_action( 'sensei_single_course_content_inside_before', array( $instance, 'display_course_participant_count' ), 14 );
 		add_action( 'sensei_course_content_inside_before', array( $instance, 'display_course_participant_count' ), 15, 1 );
 
 		// Include Widget


### PR DESCRIPTION
Fixes #72.

### Changes proposed in this Pull Request
Updates the priority of the `sensei_single_course_content_inside_before` action to 14, which executes just before the progress statement (priority 15) and the progress meter (priority 16).

### Testing instructions
* Enrol a few learners into a course that isn't using blocks.
* On the single course page, ensure the participant count is displayed above the completed lesson count.

![Screen Shot 2021-03-24 at 3 17 45 PM](https://user-images.githubusercontent.com/1190420/112371483-0a04fb80-8cb5-11eb-999b-d4b6fe75390c.jpg)